### PR TITLE
chore: update gitignore for local development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Specs (internal planning, not for public)
 spec/
 
+# Claude Code instructions (local only)
+CLAUDE.md
+
 # Dependencies
 node_modules/
 .pnp


### PR DESCRIPTION
Updates .gitignore to exclude local development configuration files.